### PR TITLE
Kirstin logo partner

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,18 +3,18 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>OpenTechSummit Berlin-Potsdam 25. Mai 2017, Open Technologies, Open Hardware, Open Source, Open Knowledge, Internet of Things, Open Data</title>
+        <title>OpenTechSummit Potsdam 25. Mai 2017, Open Technologies, Open Hardware, Open Source, Open Knowledge, Internet of Things, Open Data</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="OpenTechSummit 2017 Berlin - Europe's Premier Open Technology Event">
-        <meta name="keywords" content="OpenTechSummit, Open Technology, Open Source, Open Hardware, Open Data, Open Knowledge, Berlin, Germany, Europe">
+        <meta name="description" content="OpenTechSummit 2017 - Europe's Premier Open Technology Event">
+        <meta name="keywords" content="OpenTechSummit, Open Technology, Open Source, Open Hardware, Open Data, Open Knowledge, Open Education, Open Educational Resources, Berlin, Potsdam, Germany, Europe">
         <meta name="author" content="OpenTechSummit">
-        <meta property="og:title" content="OpenTechSummit 16" />
+        <meta property="og:title" content="OpenTechSummit 17" />
         <meta property="og:type" content="website" />
         <meta property="og:image" content="" />
         <meta name="twitter:card" content="summary">
         <meta name="twitter:site" content="@opntec">
         <meta name="twitter:title" content="OpenTechSummit">
-        <meta name="twitter:description" content="OpenTechSummit Berlin-Potsdam 25. Mai 2017, Open Technologies, Open Hardware, Open Source, Open Knowledge, Internet of Things, Open Data">
+        <meta name="twitter:description" content="OpenTechSummit Potsdam 25. Mai 2017, Open Technologies, Open Hardware, Open Source, Open Knowledge, Internet of Things, Open Data">
         <meta name="twitter:creator" content="@opntec">
         <meta name="twitter:image" content="">
         <link rel="shortcut icon" href="OpenTechSummit.ico" type="image/x-icon" />
@@ -283,7 +283,7 @@
 				<div class="container">
 					<div class="row">
 						<div class="col-md-5 col-sm-6">
-							<h1>Der OpenTechSummit findet am 25. Mai 2017 auf dem Gelände des freiLand e.V. in Potsdam statt</h1>
+							<h1>Der OpenTechSummit findet am 25. Mai 2017 auf dem Gelände des freiLand in Potsdam statt</h1>
 							<a href="./tickets" class="btn" target="_self">Tickets Erwerben</a>
 							<a href="./speaker-registration/" class="btn" target="_self">Call for Speakers</a>
 							
@@ -1069,7 +1069,7 @@
                                 </div>
                                 <div class="speaker-description">
                                     <h2>Martin Koll</h2>
-                                    <span class="sub">freiLand e.V.</span>
+                                    <span class="sub">freiLand</span>
                                 </div>
                             </div>
                         </div>
@@ -1088,7 +1088,7 @@
                                 </div>
                                 <div class="speaker-description">
                                     <h2>Kirstin Heidler</h2>
-                                    <span class="sub">Developer</span>
+                                    <span class="sub">Developer, Funding</span>
                                 </div>
                             </div>
                         </div>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>OpenTechSummit Potsdam 25. Mai 2017, Open Technologies, Open Hardware, Open Source, Open Knowledge, Internet of Things, Open Data</title>
+        <title>OpenTechSummit Potsdam/Berlin 25. Mai 2017, Open Technologies, Open Hardware, Open Source, Open Knowledge, Internet of Things, Open Data</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="description" content="OpenTechSummit 2017 - Europe's Premier Open Technology Event">
         <meta name="keywords" content="OpenTechSummit, Open Technology, Open Source, Open Hardware, Open Data, Open Knowledge, Open Education, Open Educational Resources, Berlin, Potsdam, Germany, Europe">
@@ -14,7 +14,7 @@
         <meta name="twitter:card" content="summary">
         <meta name="twitter:site" content="@opntec">
         <meta name="twitter:title" content="OpenTechSummit">
-        <meta name="twitter:description" content="OpenTechSummit Potsdam 25. Mai 2017, Open Technologies, Open Hardware, Open Source, Open Knowledge, Internet of Things, Open Data">
+        <meta name="twitter:description" content="OpenTechSummit Potsdam/Berlin 25. Mai 2017, Open Technologies, Open Hardware, Open Source, Open Knowledge, Internet of Things, Open Data">
         <meta name="twitter:creator" content="@opntec">
         <meta name="twitter:image" content="">
         <link rel="shortcut icon" href="OpenTechSummit.ico" type="image/x-icon" />
@@ -1088,7 +1088,7 @@
                                 </div>
                                 <div class="speaker-description">
                                     <h2>Kirstin Heidler</h2>
-                                    <span class="sub">Developer, Funding</span>
+                                    <span class="sub">Developer, Controlling</span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Removed the Berlin-Potsdam and replaced with Potsdam/Berlin, since Potsdam does not belong to Berlin. Kept Berlin in keywords.
Removed e.V. from freiLand since it is no e.V.
replaced a 16 with a 17 in meta-tag